### PR TITLE
Feature/run loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ clap = { version = "3.0.7", features = ["derive"] }
 colored = "2"
 phf = { version = "0.10", features = ["macros"] }
 termion = "1.5.6"
+better-panic = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ chrono = "0.4"
 clap = { version = "3.0.7", features = ["derive"] }
 colored = "2"
 phf = { version = "0.10", features = ["macros"] }
+termion = "1.5.6"

--- a/src/display.rs
+++ b/src/display.rs
@@ -28,7 +28,7 @@ pub fn print_header() {
 ///
 /// Basic usage:
 /// ```
-/// clear_terminal()
+/// clear_terminal();
 /// ```
 pub fn clear_terminal() {
     write!(stdout(),
@@ -37,4 +37,23 @@ pub fn clear_terminal() {
            termion::cursor::Goto(1, 1),
            termion::cursor::Hide)
            .unwrap();
+}
+
+/// Clears the terminal, shows the cursor at the top left and flushed stdout. Used when we are
+/// ending the program
+///
+/// # Examples
+///
+/// ```
+/// cleanup_terminal();
+/// ```
+pub fn cleanup_terminal() {
+    let mut stdout = stdout();
+    write!(stdout,
+           "{}{}{}",
+           termion::clear::All,
+           termion::cursor::Goto(1, 1),
+           termion::cursor::Show)
+           .unwrap();
+    stdout.flush().unwrap();
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,3 +1,9 @@
+use std::io::{Write, stdout};
+
+/// Prints a header for the program in the following format:
+///       Away             Home          Score       Status                                                                                                                                                             │
+///       ----             ----          -----       ------
+///
 pub fn print_header() {
     println!(
         "{}",
@@ -15,3 +21,20 @@ pub fn print_header() {
     );
 }
 
+/// Clears the terminal and repositions any output to be written at the top left of the terminal.
+/// This is used right before we write any output to the terminal.
+///
+/// # Examples
+///
+/// Basic usage:
+/// ```
+/// clear_terminal()
+/// ```
+pub fn clear_terminal() {
+    write!(stdout(),
+           "{}{}{}",
+           termion::clear::All,
+           termion::cursor::Goto(1, 1),
+           termion::cursor::Hide)
+           .unwrap();
+}

--- a/src/html_parser.rs
+++ b/src/html_parser.rs
@@ -9,6 +9,8 @@ fn get_team_names(game_block: select::node::Node) -> (String, String) {
         .map(|tag| tag.text())
         .collect::<Vec<String>>();
 
+    // TODO: panicking here when (I'm assuming) we don't have an HTML document to actually parse --
+    // it failed to read the site
     let away_team_name = String::from(teams.get(0).expect("No team names in this vector"));
     let home_team_name = String::from(teams.get(1).expect("No team names in this vector"));
     return (home_team_name, away_team_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,13 +70,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url_base = String::from("https://scores.nbcsports.com/nba/scoreboard.asp?day=");
     let url = url_base + &date;
 
-    // loop here
+    //stdin controls user input
+    // program loop -- re-fetch html and display games every 10 seconds
     let mut stdin = async_stdin().bytes();
     'program_loop: loop {
-        //let stdin = stdin.lock();
         // controller for detecting 'q' key to exit program
         // clear terminal
-        //print!("\x1B[2J");
         // Get the webpage
         let resp = reqwest::get(&url).await?;
         assert!(resp.status().is_success());
@@ -84,12 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // clear terminal and set program to write in top left of terminal
         // TODO: Functionalize this (1)
-        write!(stdout(),
-               "{}{}{}",
-               termion::clear::All,
-               termion::cursor::Goto(1, 1),
-               termion::cursor::Hide)
-               .unwrap();
+        clear_terminal();
         print_header();
 
         for row in document.find(Class("shsScoreboardRow")) {
@@ -135,13 +129,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             counter += 1;
             // wait 10 seconds before re-running program
             if counter * sleep_time_in_ms >= 10000 {
-            // TODO: Functionalize this (1)
-            write!(stdout,
-                   "{}{}{}",
-                   termion::clear::All,
-                   termion::cursor::Goto(1, 1),
-                   termion::cursor::Hide)
-                   .unwrap();
                 break 'inner;
             }
         }
@@ -151,4 +138,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         //break 'program_loop
     }
     return Ok(());
+}
+
+
+fn clear_terminal() {
+    write!(stdout(),
+           "{}{}{}",
+           termion::clear::All,
+           termion::cursor::Goto(1, 1),
+           termion::cursor::Hide)
+           .unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,8 +83,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let document = Document::from(&*resp.text().await?);
 
         // clear terminal and set program to write in top left of terminal
-        print!("\x1B[2J");
-        write!(stdout(), "{}", termion::cursor::Goto(1, 1)).unwrap();
+        // TODO: Functionalize this (1)
+        write!(stdout(),
+               "{}{}{}",
+               termion::clear::All,
+               termion::cursor::Goto(1, 1),
+               termion::cursor::Hide)
+               .unwrap();
         print_header();
 
         for row in document.find(Class("shsScoreboardRow")) {
@@ -115,7 +120,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(Ok(b'q')) = b {
                 // clean up and end program
                 print!("\x1B[2J");
-                write!(stdout, "{}", termion::cursor::Goto(1, 1)).unwrap();
+                write!(stdout,
+                       "{}{}",
+                       termion::cursor::Goto(1, 1),
+                       termion::cursor::Show)
+                       .unwrap();
                 stdout.flush().unwrap();
                 break 'program_loop;
             }
@@ -126,11 +135,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             counter += 1;
             // wait 10 seconds before re-running program
             if counter * sleep_time_in_ms >= 10000 {
-                write!(stdout,
-                       "{}{}",
-                       termion::clear::All,
-                       termion::cursor::Goto(1, 1))
-                       .unwrap();
+            // TODO: Functionalize this (1)
+            write!(stdout,
+                   "{}{}{}",
+                   termion::clear::All,
+                   termion::cursor::Goto(1, 1),
+                   termion::cursor::Hide)
+                   .unwrap();
                 break 'inner;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert!(resp.status().is_success());
         let document = Document::from(&*resp.text().await?);
 
+        // clear terminal and set program to write in top left of terminal
+        print!("\x1B[2J");
+        write!(stdout(), "{}", termion::cursor::Goto(1, 1)).unwrap();
         print_header();
 
         for row in document.find(Class("shsScoreboardRow")) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // external packages
 extern crate reqwest;
+use std::{thread, time};
 use chrono;
 use clap::Parser;
 use select::document::Document;
@@ -56,25 +57,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url_base = String::from("https://scores.nbcsports.com/nba/scoreboard.asp?day=");
     let url = url_base + &date;
 
-    // Get the webpage
-    let resp = reqwest::get(url).await?;
-    assert!(resp.status().is_success());
-    let document = Document::from(&*resp.text().await?);
+    // loop here
+    while true {
+        // Get the webpage
+        let resp = reqwest::get(&url).await?;
+        assert!(resp.status().is_success());
+        let document = Document::from(&*resp.text().await?);
 
-    print_header();
+        print_header();
 
-    for row in document.find(Class("shsScoreboardRow")) {
-        // there are two games per row
-        for game_block in row.find(Class("shsScoreboardCol")) {
-            // given a game block, form two Teams and a Game
-            // parse the current game block for game info
-            let game: Game = form_game(game_block);
-            //println!("{:?}", game.home_team);
-            //println!("{:?}", game.away_team);
+        for row in document.find(Class("shsScoreboardRow")) {
+            // there are two games per row
+            for game_block in row.find(Class("shsScoreboardCol")) {
+                // given a game block, form two Teams and a Game
+                // parse the current game block for game info
+                let game: Game = form_game(game_block);
+                //println!("{:?}", game.home_team);
+                //println!("{:?}", game.away_team);
 
-            // print current game info to terminal
-            game.display();
+                // print current game info to terminal
+                game.display();
+            }
         }
+        let sleep_time = time::Duration::from_secs(10);
+        thread::sleep(sleep_time);
     }
     return Ok(());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ mod timezones;
 use crate::date_handler::extract_date_argument;
 use crate::display::print_header;
 use crate::game::Game;
-use crate::display::clear_terminal;
+use crate::display::{clear_terminal, cleanup_terminal};
 use crate::html_parser::form_game;
 
 // TODO:
@@ -111,6 +111,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let b = stdin.next();
             // this is the async read input char, it looks for user input
             write!(stdout, "\r").unwrap();
+            // cases for buttons to press
+            // TODO: Refactor into key handling module
             if let Some(Ok(b'q')) = b {
                 // clean up and end program
                 cleanup_terminal();
@@ -118,7 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             // debug key
             if let Some(Ok(b'd')) = b {
-                panic!("Debug button Pressed!");
+                println!("Debug button Pressed!");
             }
 
             let sleep_time_in_ms = 50;
@@ -132,17 +134,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     return Ok(());
-}
-
-fn cleanup_terminal() {
-    let mut stdout = stdout();
-    write!(stdout,
-           "{}{}{}",
-           termion::clear::All,
-           termion::cursor::Goto(1, 1),
-           termion::cursor::Show)
-           .unwrap();
-    stdout.flush().unwrap();
 }
 
 fn setup_panic_hook() {


### PR DESCRIPTION
* Functionality for the program to run in a continuous loop, scraping and displaying scores every 10 seconds. 
* Screen clearing and cleanup functionality
* Implemented key handling events. So far we have `q` which quits the program and `d` which prints a debug message.
* Found a rare bug that occurs when (i think) we do not successfully scrape the html page resulting in no document to parse -- producing an error. This bug should not be fixed in this pull request as it is a feature implementation branch, but I included a comment in `html_parser.rs` to keep track of where the bug occurs.